### PR TITLE
fix for #336 RN 0.59 notice

### DIFF
--- a/src/user/User.js
+++ b/src/user/User.js
@@ -1,4 +1,4 @@
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-community/async-storage';
 
 import Data from '../Data';
 import { hashPassword } from '../../lib/utils';


### PR DESCRIPTION
RN 0.59 notice, AsyncStorage out of RN core and distributed as '@react-native-community/async-storage'